### PR TITLE
added a new unreviewed journal endpoint

### DIFF
--- a/src/repositories/journal.repository.ts
+++ b/src/repositories/journal.repository.ts
@@ -29,4 +29,16 @@ export class JournalRepository extends DefaultCrudRepository<
     this.project = this.createBelongsToAccessorFor('project', projectRepositoryGetter,);
     this.registerInclusionResolver('project', this.project.inclusionResolver);
   }
+
+  async findUnreviewedJournal(): Promise<Journal[]> {
+    return await this.find({
+      where: {
+        or: [
+          { status: 'new' },
+          { status: 'updated' },
+          { status: 'discuss' }
+        ]
+      }
+    });
+  }
 }


### PR DESCRIPTION
Signed-off-by: Ahmad Shah Hafizan Hamidin <ahmadshahhafizan@gmail.com>

Added a new endpoint to retrieve the following:

1. ```/journal``` - this will return ```unreviewed``` journals
2. ```/journal/all``` - this will return all journals regardless of the journal status

This PR also introduce a functionality whereby if a normal user updates the journal entry, status will be changed to ```updated```.

Refer to issue #30 