### PR TITLE
Changed endpoint for forgot password from GET to POST

### DIFF
--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -462,7 +462,7 @@ export class UserController {
     return this.userRepository.findById(user.user);
   }
 
-  @get('/user/forget/email/{email}', {
+  @post('/user/forget/email', {
     responses: {
       '200': {
         description: 'Forget password',
@@ -470,11 +470,26 @@ export class UserController {
     },
   })
   async forgetPasswordByEmail(
-    @param.path.string('email') userEmail: string,
+    @requestBody({
+      required: true,
+      content: {
+        'application/x-www-form-urlencoded': {
+          schema: {
+            type: 'object',
+            required: ['email'],
+            properties: {
+              email: {
+                type: 'string',
+              }
+            }
+          }
+        }
+      }
+    }) forgetemail: {email: string}
   ): Promise<{result: Boolean}> {
     let bRetCode = false;
     const userExisted = await this.userRepository.findOne({
-      where: {email: userEmail},
+      where: {email: forgetemail.email},
     });
 
     if (!userExisted) {

--- a/src/datasources/file.datasource.ts
+++ b/src/datasources/file.datasource.ts
@@ -4,11 +4,11 @@ import {juggler} from '@loopback/repository';
 const config = {
   name: 'File',
   connector: 'loopback-component-storage',
-  provider: process.env.STORAGE_PROVIDER,
-  key: process.env.STORAGE_PROVIDER_KEY,
-  keyId: process.env.STORAGE_PROVIDER_KEY_ID,
-  // provider: 'filesystem',
-  // root: './storage',
+  // provider: process.env.STORAGE_PROVIDER,
+  // key: process.env.STORAGE_PROVIDER_KEY,
+  // keyId: process.env.STORAGE_PROVIDER_KEY_ID,
+  provider: 'filesystem',
+  root: './storage',
   nameConflict: 'makeUnique',
   makeUnique: true
 };

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -47,37 +47,40 @@ export class EmailService {
       throw new HttpErrors.InternalServerError('Invalid Email. Please make sure there is an email template under the code')
     }
 
-    const body = ejs.render(bodyContent.body!, data)
+    // data need to be sent as an object
+    const body = ejs.render(bodyContent.body!, {data})
 
+    /* No longer needed to reduce logic processing */
     // Setup email container
-    const container = await this.emailTemplateRepository.findOne({
-      where: {code: 'CONTAINER'}
-    })
+    // const container = await this.emailTemplateRepository.findOne({
+    //   where: {code: 'CONTAINER'}
+    // })
 
-    const headerContent = await this.emailTemplateRepository.findOne({
-      where: {code: 'HEADER'}
-    })
+    // const headerContent = await this.emailTemplateRepository.findOne({
+    //   where: {code: 'HEADER'}
+    // })
 
-    const footerContent = await this.emailTemplateRepository.findOne({
-      where: {code: 'FOOTER'}
-    })
+    // const footerContent = await this.emailTemplateRepository.findOne({
+    //   where: {code: 'FOOTER'}
+    // })
 
-    if(!container || !headerContent || !footerContent || !bodyContent) {
+    if(!bodyContent) {
       throw new HttpErrors.InternalServerError('Internal error. Please reseed a fresh copy of email templates.')
     }
 
-    const template = ejs.render(container.body!, {
-      content: {
-        header: headerContent.body,
-        footer: footerContent.body,
-        body: body
-      }
-    })
+    /* render method did not has any key named as 'content' */
+    // const template = ejs.render(container.body!, {
+    //   content: {
+    //     header: headerContent.body,
+    //     footer: footerContent.body,
+    //     body: body
+    //   }
+    // })
 
     const email = new Email({
       to: to,
       subject: bodyContent.subject,
-      content: template,
+      content: body, // Sent the whole body of PASSWORDRESET as a whole including header and footer
     });
 
     return this.sendMail(email)


### PR DESCRIPTION
Enhancement for #33 

Signed-off-by: zaimazhar97 <54124001+zaimazhar97@users.noreply.github.com>

**Proposed Solution**
Changed the endpoint GET of '/user/forget/email/{email}' to POST of '/user/forget/email'.

**Solution Detailed**
For security purpose, the POST endpoint takes value from the request body (required email field) which needs to be submitted via the HTTP POST method or else it will not send the value to the backend properly. Unlike query string in the URI which can lead to disastrous email phishing.